### PR TITLE
fix: update validate_map to also consider the grid size 

### DIFF
--- a/mars_rovers.rb
+++ b/mars_rovers.rb
@@ -22,7 +22,7 @@ def mars_rovers(world, *args)
       end
     end
 
-    x, y, lost = validate_map(x, y)
+    x, y, lost = validate_map(x, y, world)
 
     puts "(#{x}, #{y}, #{o})#{lost}"
   end
@@ -51,8 +51,10 @@ def turn orientation, action
   compass[compass.index(orientation) + direction]
 end
 
-def validate_map x, y
-  lost = (x.negative? || y.negative?) ? ' LOST' : ''
+def validate_map x, y, world
+  m, n = world.split.map(&:to_i)
+  lost = ( x.negative? || y.negative? || x > m || y > n ) ? ' LOST' : ''
+
   x = 0 if x.negative?
   y = 0 if y.negative?
 


### PR DESCRIPTION
**Description**

If a rover exits the map we want to output `LOST`.

Currently, this works only if the rover has exited through the South or West edges of the map. 

This PR makes sure that `LOST` is returned also for rovers exiting the map through the North and East.

**Screenshots**
<img width="509" alt="Screenshot 2022-09-08 at 13 28 51" src="https://user-images.githubusercontent.com/60197762/189121907-97e0a403-2cc3-46d9-9bbc-ef84fd924696.png">

